### PR TITLE
fix(component-overview): font and border of cards

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -19,7 +19,7 @@
 }
 
 .bx--list--ordered {
-  margin-left: .8125rem;
+  margin-left: 0.8125rem;
 
   .bx--list__item {
     margin-left: 0.5rem;
@@ -31,11 +31,17 @@
   padding: 0;
 }
 
+.bx--image-card__img .gatsby-resp-image-wrapper {
+  border-right: 1px solid #e0e0e0;
+  left: 0;
+}
+
 // Overriding ImageCard size of titles
 .bx--image-card__title {
-  font-size: var(--cds-heading-01-font-size, 0.875rem);
-  line-height: var(--cds-heading-01-line-height, 1.125rem);
-  letter-spacing: var(--cds-heading-01-letter-spacing, 0.16px);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1rem;
+  letter-spacing: 0.32px;
 }
 
 // overriding code style in tables


### PR DESCRIPTION
### Related Ticket(s)

Dev assistant for Cupcake website page content fix (Sprint 24) #63

### Description

Take styling from the carbon site and apply to card title and add border

BEFORE:
<img width="697" alt="Screen Shot 2019-12-20 at 5 05 58 PM" src="https://user-images.githubusercontent.com/54281166/71295750-3c55d980-234b-11ea-8bdd-13679cec292a.png">

AFTER:
<img width="629" alt="Screen Shot 2019-12-20 at 5 05 29 PM" src="https://user-images.githubusercontent.com/54281166/71295798-68715a80-234b-11ea-888e-c84a30b1e065.png">

