### PR TITLE
docs(coding): removing patterns and pointing to vanilla

### DIFF
--- a/src/pages/getting-started/coding.mdx
+++ b/src/pages/getting-started/coding.mdx
@@ -47,7 +47,7 @@ IBM.com Library provides front-end developers and engineers a collection of reus
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Components (React)"
+  subTitle="IBM.com Library Components and Patterns (React)"
   href="https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/react"
 >
 
@@ -57,8 +57,8 @@ IBM.com Library provides front-end developers and engineers a collection of reus
 
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="IBM.com Library Patterns (React)"
-      href="https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/patterns-react"
+      subTitle="IBM.com Library Components (Vanilla)"
+      href="https://github.com/carbon-design-system/ibm-dotcom-library/tree/master/packages/vanilla"
     >
 
 ![Github](./../../images/icon/github-icon.svg)


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This removed the pointer to patterns react since that package no longer exists. I switched it to vanilla, though not much is there at the moment...

Coding page: https://ibmdotcom-library.s3.us-south.cloud-object-storage.appdomain.cloud/deploy-previews/319/getting-started/coding/index.html

### Changelog

**Changed**

- Coding page
