### PR TITLE
fix(scss): added border to image-cards on components overview

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -30,7 +30,7 @@
 
 .image-card-group .bx--no-gutter-sm:nth-of-type(even) {
   .bx--image-card--dark {
-    border-left: 1px solid #e0e0e0;
+    border-left: 1px solid $ui-03;
   }
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -28,6 +28,12 @@
   }
 }
 
+.image-card-group .bx--no-gutter-sm:nth-of-type(even) {
+  .bx--image-card--dark {
+    border-left: 1px solid #e0e0e0;
+  }
+}
+
 // Overriding ImageCard size of titles
 .bx--image-card__title {
   font-size: var(--cds-heading-01-font-size, 0.875rem);


### PR DESCRIPTION
### Related Ticket(s)

#1324

### Description

Added the right border color to the image cards on the components overview page.