### PR TITLE
FIX: research database site link

### DIFF
--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -238,8 +238,8 @@ Digital Design System delivers the [IBM Design Language](https://www.ibm.com/des
   
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM research data base"
-  href="https://www.ibm.com/standards/web/research/"
+  subTitle="IBM User Research Library (CIO)"
+  href="https://lux.w3ibm.mybluemix.net/library/"
 >
 
 ![Sketch icon](../../images/bee_icon.svg)


### PR DESCRIPTION
Pointing to the new website, the old one is broken.

### Related Ticket(s)

N/A

### Description

The link to the research database site is outdated. This changes the label of the card and link to the correct one: https://lux.w3ibm.mybluemix.net/library/

### Changelog

**Changed**

- The label of the research data base card
- The URL the card links to
