### PR TITLE
feat(white-theme): resources cards in white theme

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -46,7 +46,6 @@ building websites and user interfaces. See a
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      color="white"
       subTitle="Sketch Theme libraries"
       actionIcon="arrowRight"
       href="/resources#theme-libraries"
@@ -58,7 +57,6 @@ building websites and user interfaces. See a
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
    <ResourceCard
-       color="white"
        subTitle="IBM.com Library Components Repo"
        href="https://github.com/carbon-design-system/ibm-dotcom-library"
        >
@@ -69,7 +67,6 @@ building websites and user interfaces. See a
   </Column>
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    color="white"
     subTitle="IBM.com Library Components React Storybook"
     href="https://ibmdotcom-react.mybluemix.net/?path=/story/overview--get-started"
     >
@@ -80,7 +77,6 @@ building websites and user interfaces. See a
 </Column>
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    color="white"
     subTitle="IBM.com Library Pattern React Storybook"
     href="https://ibmdotcom-patterns-react-experimental.mybluemix.net/?path=/story/overview--get-started"
     >

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -46,7 +46,7 @@ building websites and user interfaces. See a
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      color="dark"
+      color="white"
       subTitle="Sketch Theme libraries"
       actionIcon="arrowRight"
       href="/resources#theme-libraries"
@@ -58,34 +58,34 @@ building websites and user interfaces. See a
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
    <ResourceCard
-       color="dark"
+       color="white"
        subTitle="IBM.com Library Components Repo"
        href="https://github.com/carbon-design-system/ibm-dotcom-library"
        >
 
-![Github icon](./../images/icon/github-inverse-icon.svg)
+![Github icon](./../images/icon/github-icon.svg)
 
 </ResourceCard>
   </Column>
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    color="dark"
+    color="white"
     subTitle="IBM.com Library Components React Storybook"
     href="https://ibmdotcom-react.mybluemix.net/?path=/story/overview--get-started"
     >
 
-![React icon](../images/icon/react-blue-icon.svg)
+![React icon](../images/icon/react-icon.svg)
 
   </ResourceCard>
 </Column>
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    color="dark"
+    color="white"
     subTitle="IBM.com Library Pattern React Storybook"
     href="https://ibmdotcom-patterns-react-experimental.mybluemix.net/?path=/story/overview--get-started"
     >
 
-![React icon](../images/icon/react-blue-icon.svg)
+![React icon](../images/icon/react-icon.svg)
 
   </ResourceCard>
 </Column>

--- a/src/styles/_homepage.scss
+++ b/src/styles/_homepage.scss
@@ -1,10 +1,15 @@
+.container--homepage {
+  background: $ui-01;
+  color: $carbon--black-100;
+}
+
 // Dots background pattern
 .homepage--dots {
   position: fixed;
   z-index: 1;
   width: 100%;
   height: 100%;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 16 16' style='enable-background:new 0 0 16 16;' xml:space='preserve'%3e%3crect width='16' fill='none' height='16'/%3e%3crect x='0' y='0' fill='white' width='1' height='1'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 16 16' style='enable-background:new 0 0 16 16;' xml:space='preserve'%3e%3crect width='16' fill='none' height='16'/%3e%3crect x='0' y='0' fill='black' width='1' height='1'/%3e%3c/svg%3e");
   background-size: 16px;
   opacity: 0.35;
 }


### PR DESCRIPTION
### Related Ticket(s)

Gatsby homepage code review for the new white theme design - Other resources section #383

### Description

Resources Cards Section in white theme 

<img width="1247" alt="Screen Shot 2020-05-12 at 1 45 52 PM" src="https://user-images.githubusercontent.com/54281166/81727439-f7942180-9456-11ea-9873-bce3b4ca4a0c.png">

### Changelog

**Changed**

- overwrite carbon's homepage template styles to have white background and black text
- change resource card backgrounds with white and icons

