### PR TITLE
docs(resources): adding nextjs template link

### DIFF
--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -30,6 +30,15 @@ Everything you need to learn about, work with, and contribute to IBM.com Library
 ![Github icon](./../../images/icon/github-icon.svg)
 </ResourceCard>
   </Column>
+  <Column colMd={4} colLg={4} noGutterSm>
+<ResourceCard
+  subTitle="IBM.com Library NextJS Template"
+  href="https://github.com/carbon-design-system/ibm-dotcom-library-nextjs-template"
+>
+
+![Github icon](./../../images/icon/github-icon.svg)
+</ResourceCard>
+  </Column>
 </Row>
 
 ### Storybook


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This adds the new resource link for the NextJS template

### Changelog

**Changed**

- Resources page includes link to the NextJS Template