### PR TITLE
fix(Guidelines): adjust table container overflow-x for md+ breakpoints

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -46,3 +46,12 @@
 td > code {
   white-space: nowrap;
 }
+
+// remove horizontal scroll in breakpoints > mobile
+.page-table__container {
+  overflow-x: auto;
+
+  @include carbon--breakpoint("md") {
+    overflow-x: initial;
+  }
+}


### PR DESCRIPTION
### Related Ticket(s)

{{Provide url(s) to the related ticket(s) that this pull request addresses}}

### Description

Set `overflow-x` to `auto` for mobile breakpoints. Larger breakpoints, the table should shrink/grow to fit text

### Changelog

**Changed**

- have `overflow-x: auto` for mobile breakpoint only