### PR TITLE
feat(rename): renaming to Carbon for IBM.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ about: Something isn't working as expected? Here is the right place to report.
 
 > What browser are you working in?
 
-> What version of the IBM.com Library are you using?
+> What version of Carbon for IBM.com are you using?
 
 > What offering/product do you work on? Any pressing ship or release dates we
 > should be aware of?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question 🤔
-about: Usage question or discussion about the IBM.com Library.
+about: Usage question or discussion about Carbon for IBM.com.
 ---
 
 <!--
@@ -12,7 +12,7 @@ share a couple resources that you could use if you haven't tried them yet 🙂.
 If you're an IBMer, we have a couple of Slack channels available across all IBM
 Workspaces:
 
-- #ibm-digital-design for questions about the IBM.com Library
+- #ibm-digital-design for questions about Carbon for IBM.com
 - #carbon-design-system for questions about the Design System
 - #carbon-components for questions about component styles
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,7 +1,7 @@
 # Support
 
 If you run into an issue, sorry about that! We definitely want to make sure that
-your experience using the IBM.com Library is the best that it can be.
+your experience using Carbon for IBM.com is the best that it can be.
 
 When this happens, just create an issue on GitHub by filling out the template
 and we'll try our best to respond in a reasonable time.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">
-  IBM.com Library Website
+  Carbon for IBM.com Website
 </h1>
 
-This is the IBM.com Library website, which includes documentation and guidelines around design and development for IBM.com.
+This is the Carbon for IBM.com website, which includes documentation and guidelines around design and development for IBM.com.
 
 This is based on the [Gatsby Theme from Carbon](https://gatsby-theme-carbon.now.sh/).
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,8 +5,8 @@ require("dotenv").config({
 module.exports = {
   pathPrefix: process.env.PATH_PREFIX || "/",
   siteMetadata: {
-    title: 'IBM.com Library',
-    description: 'This is the IBM.com Library website, which includes documentation and guidelines around design and development for IBM.com',
+    title: 'Carbon for IBM.com',
+    description: 'This is the Carbon for IBM.com website, which includes documentation and guidelines around design and development for IBM.com',
     keywords: 'gatsby,theme,carbon,ibm',
   },
   plugins: [

--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -155,7 +155,7 @@
 #      path: /resources/design-kit
 #    - title: Drupal
 #      path: /resources/drupal
-#    - title: IBM.com Library
+#    - title: Carbon for IBM.com
 #      path: /resources/ibm-dotcom-library
 #    - title: Research
 #      path: /resources/research

--- a/src/gatsby-theme-carbon/components/Header.js
+++ b/src/gatsby-theme-carbon/components/Header.js
@@ -3,7 +3,7 @@ import Header from 'gatsby-theme-carbon/src/components/Header';
 
 const CustomHeader = props => (
   <Header {...props}>
-    <span>IBM.com Library</span>
+    <span>Carbon for IBM.com</span>
   </Header>
 );
 

--- a/src/pages/components/gallery.mdx
+++ b/src/pages/components/gallery.mdx
@@ -8,12 +8,12 @@ import ComponentGallery from 'components/ComponentGallery';
 
 <PageDescription>
 
-Components are one of the key building blocks of the design system. Each component has been designed and coded to solve a specific UI or layout problem, such as presenting a list of options, enabling submission of a form, providing feedback to the user, and so on. All of the components in IBM.com Library have been designed to work harmoniously together, as parts of a greater whole.
+Components are one of the key building blocks of the design system. Each component has been designed and coded to solve a specific UI or layout problem, such as presenting a list of options, enabling submission of a form, providing feedback to the user, and so on. All of the components in Carbon for IBM.com have been designed to work harmoniously together, as parts of a greater whole.
 
 </PageDescription>
 
 
-## IBM.com Library components 
+## Carbon for IBM.com components 
 
 ### UI Components
 Components that are designed and built to support or enable small UI tasks and actions. They can be paired with other components to create layout components, templates, and patterns.

--- a/src/pages/components/leadspace.mdx
+++ b/src/pages/components/leadspace.mdx
@@ -336,4 +336,4 @@ For further developer guidance view the LeadSpace README.md [here](https://githu
 ## Metadata 
 * Components: [Button](https://www.carbondesignsystem.com/components/button/code/)
 * Elements: [Photography](https://www.ibm.com/design/language/elements/photography/overview/)
-* Github: [IBM.com Library](https://github.com/carbon-design-system/ibm-dotcom-library)
+* Github: [Carbon for IBM.com](https://github.com/carbon-design-system/ibm-dotcom-library)

--- a/src/pages/components/overview.mdx
+++ b/src/pages/components/overview.mdx
@@ -8,12 +8,12 @@ import { ComponentList, TagKey } from 'components/ComponentList';
 
 <PageDescription>
 
-Components are one of the key building blocks of the design system. Each component has been designed and coded to solve a specific UI or layout problem, such as presenting a list of options, enabling submission of a form, providing feedback to the user, and so on. All of the components in IBM.com Library have been designed to work harmoniously together, as parts of a greater whole.
+Components are one of the key building blocks of the design system. Each component has been designed and coded to solve a specific UI or layout problem, such as presenting a list of options, enabling submission of a form, providing feedback to the user, and so on. All of the components in Carbon for IBM.com have been designed to work harmoniously together, as parts of a greater whole.
 
 </PageDescription>
 
 
-## IBM.com Library components 
+## Carbon for IBM.com components 
 
 ### UI Components
 Components that are designed and built to support or enable small UI tasks and actions. They can be paired with other components to create layout components, templates, and patterns.

--- a/src/pages/contributions/index.mdx
+++ b/src/pages/contributions/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Contributions
-description: Interested in contributing to IBM.com Library? This design system is the result of community contributions, large and small--of code, design, ideas, and guidance. Here's how you can contribute too.
+description: Interested in contributing to Carbon for IBM.com? This design system is the result of community contributions, large and small--of code, design, ideas, and guidance. Here's how you can contribute too.
 ---
 
 <PageDescription>
 
-Interested in contributing to IBM.com Library? IBM.com Library is the work product of our dedicated community member’s contributions, large and small, of code, design, ideas, and thought leadership. Below are instructions on how you can contribute, too.
+Interested in contributing to Carbon for IBM.com? Carbon for IBM.com is the work product of our dedicated community member’s contributions, large and small, of code, design, ideas, and thought leadership. Below are instructions on how you can contribute, too.
 
 </PageDescription>
 
@@ -13,7 +13,7 @@ Interested in contributing to IBM.com Library? IBM.com Library is the work produ
 
 <AnchorLink>Introduction</AnchorLink>
 <AnchorLink>Working in the open</AnchorLink>
-<AnchorLink>IBM.com Library community</AnchorLink>
+<AnchorLink>Carbon for IBM.com community</AnchorLink>
 <AnchorLink>Project workflow</AnchorLink>
 
 </AnchorLinks>
@@ -21,7 +21,7 @@ Interested in contributing to IBM.com Library? IBM.com Library is the work produ
 
 ## Introduction
 
-IBM.com Library was created to build dynamic IBM web pages and digital experiences on IBM.com. The IBM.com Library community continues to evolve, and contributors like you have helped make what is now, and what it will be in the future. 
+Carbon for IBM.com was created to build dynamic IBM web pages and digital experiences on IBM.com. The IBM.com Library community continues to evolve, and contributors like you have helped make what is now, and what it will be in the future. 
 
 Contributions are not limited to code. We also encourage feedback, documentation, new designs, and tools in our toolkit. Most contributions begin with a GitHub issue using one of these templates:
 

--- a/src/pages/events/summit-2020/agenda.mdx
+++ b/src/pages/events/summit-2020/agenda.mdx
@@ -1,6 +1,6 @@
 ---
 title: Digital Design Summit
-description: Internal design summit for Carbon and IBM.com Library adopters
+description: Internal design summit for Carbon and Carbon for IBM.com adopters
 tabs: ['Introduction', 'Agenda']
 ---
 

--- a/src/pages/events/summit-2020/introduction.mdx
+++ b/src/pages/events/summit-2020/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Digital Design Summit
-description: Internal design summit for Carbon and IBM.com Library adopters
+description: Internal design summit for Carbon and Carbon for IBM.com adopters
 ---
 
 import Profile from "../../../components/Profile";
@@ -51,7 +51,7 @@ Join two days of high impact sessions where you will learn how the Carbon Design
 
 ## Our vision
 
-As we accelerate IBM's digital transformation, we have a unique opportunity to reimagine and rebuild how our users use IBM.com and get their jobs done. And to achieve this goal, we have the new IBM Design Language, Carbon Design System, IBM.com Library, and the corporate-wide initiatives to support this work. This summit is to share the latest and align ourselves to the future of IBM.com.
+As we accelerate IBM's digital transformation, we have a unique opportunity to reimagine and rebuild how our users use IBM.com and get their jobs done. And to achieve this goal, we have the new IBM Design Language, Carbon Design System, Carbon for IBM.com, and the corporate-wide initiatives to support this work. This summit is to share the latest and align ourselves to the future of IBM.com.
 
 ## Background
 

--- a/src/pages/events/summit-2020/resources.mdx
+++ b/src/pages/events/summit-2020/resources.mdx
@@ -1,12 +1,12 @@
 ---
 title: Digital Design Summit
-description: Internal design summit for Carbon and IBM.com Library adopters
+description: Internal design summit for Carbon and Carbon for IBM.com adopters
 tabs: ['Introduction', 'Agenda']
 ---
 
 <PageDescription>
 
-As we accelerate IBM's digital transformation, we have a unique opportunity to reimagine and rebuild how our users use IBM.com and get their jobs done. And to achieve this goal, we have the new IBM Design Langauage, Carbon Design System, IBM.com Library, as well as some of the core corporate-wide initiatives. This summit is to share the latest, and align ourselves to the future of IBM.com.
+As we accelerate IBM's digital transformation, we have a unique opportunity to reimagine and rebuild how our users use IBM.com and get their jobs done. And to achieve this goal, we have the new IBM Design Langauage, Carbon Design System, Carbon for IBM.com, as well as some of the core corporate-wide initiatives. This summit is to share the latest, and align ourselves to the future of IBM.com.
 
 </PageDescription>
 
@@ -22,7 +22,7 @@ As we accelerate IBM's digital transformation, we have a unique opportunity to r
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library"
+  subTitle="Carbon for IBM.com"
   href="https://github.com/carbon-design-system/ibm-dotcom-library"
 >
 
@@ -31,7 +31,7 @@ As we accelerate IBM's digital transformation, we have a unique opportunity to r
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library NextJS Template"
+  subTitle="Carbon for IBM.com NextJS Template"
   href="https://github.com/carbon-design-system/ibm-dotcom-library-nextjs-template"
 >
 
@@ -45,7 +45,7 @@ As we accelerate IBM's digital transformation, we have a unique opportunity to r
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Storybook React"
+  subTitle="Carbon for IBM.com Storybook React"
   href="https://ibmdotcom-react.mybluemix.net"
 >
 
@@ -56,7 +56,7 @@ As we accelerate IBM's digital transformation, we have a unique opportunity to r
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Storybook Web Components"
+  subTitle="Carbon for IBM.com Storybook Web Components"
   href="https://ibmdotcom-web-components.mybluemix.net"
 >
 
@@ -114,11 +114,11 @@ As we accelerate IBM's digital transformation, we have a unique opportunity to r
 
 ## Design resources
 
-### IBM.com Library
+### Carbon for IBM.com
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="Request access to the IBM.com Library design kit"
+  subTitle="Request access to the Carbon for IBM.com design kit"
   href="https://github.com/carbon-design-system/ibm-dotcom-library-design-kit/issues/new?assignees=ljcarot%2C+wonilsuhibm%2C+oliviaflory&labels=adopter+support&template=request-access.md&title=Design+kit+access+request"
 >
 
@@ -254,10 +254,10 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
 <br/>
 
 #### IBM Plex 
-IBM.com Library uses the open-source typeface [IBM Plex](https://github.com/ibm/plex) – carefully designed to meet IBM’s needs as a global technology company and reflect IBM’s spirit, beliefs, and design principles.
+Carbon for IBM.com uses the open-source typeface [IBM Plex](https://github.com/ibm/plex) – carefully designed to meet IBM’s needs as a global technology company and reflect IBM’s spirit, beliefs, and design principles.
 
 #### IBM Design Language
-IBM.com Library delivers the [IBM Design Language](https://www.ibm.com/design/language/) as tools for designers and developers, guidance, tutorials, and support. 
+Carbon for IBM.com delivers the [IBM Design Language](https://www.ibm.com/design/language/) as tools for designers and developers, guidance, tutorials, and support. 
 
 #### Carbon Design System
 [Carbon](https://www.carbondesignsystem.com) is the open-source design system for IBM products experiences. 

--- a/src/pages/get-started/coding.mdx
+++ b/src/pages/get-started/coding.mdx
@@ -5,12 +5,12 @@ description: Getting started coding page
 
 <PageDescription>
 
-Rapidly build beautiful and accessible experiences. IBM.com Library contains all the resources you need to get started. 
+Rapidly build beautiful and accessible experiences. Carbon for IBM.com contains all the resources you need to get started. 
 
 </PageDescription>
 
 <AnchorLinks>
-<AnchorLink>IBM.com Library</AnchorLink>
+<AnchorLink>Carbon for IBM.com</AnchorLink>
 <AnchorLink>Get started</AnchorLink>
 <AnchorLink>Building for IBM.com</AnchorLink>
 <AnchorLink>IBM.com Shell</AnchorLink>
@@ -22,9 +22,9 @@ Rapidly build beautiful and accessible experiences. IBM.com Library contains all
 </AnchorLinks>
 
 
-## IBM.com Library
+## Carbon for IBM.com
 
-IBM.com Library provides front-end developers and engineers a collection of reusable components to build websites and 
+Carbon for IBM.com provides front-end developers and engineers a collection of reusable components to build websites and 
 user interfaces quickly and efficiently. Adopting the library enables developers to use consistent markup, styles, and 
 behavior in prototype and production work. 
 
@@ -48,7 +48,7 @@ View the Web Components version at [Storybook Web Components](http://ibmdotcom-w
 
 If you are looking to build out a light static site, the 
 [NextJS template](https://github.com/carbon-design-system/ibm-dotcom-library-nextjs-template) is available (using the 
-React version of the IBM.com Library). This includes the default configurations for the `<DotcomShell>`, as well as 
+React version of the Carbon for IBM.com). This includes the default configurations for the `<DotcomShell>`, as well as 
 some sample components to get you started.
 
 ### Available Components
@@ -56,7 +56,7 @@ some sample components to get you started.
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Storybook React"
+  subTitle="Carbon for IBM.com Storybook React"
   href="https://ibmdotcom-react.mybluemix.net/"
 >
 
@@ -67,7 +67,7 @@ some sample components to get you started.
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Storybook Web Components"
+  subTitle="Carbon for IBM.com Storybook Web Components"
   href="https://ibmdotcom-web-components.mybluemix.net/"
 >
 
@@ -86,7 +86,7 @@ The expressive theme for Carbon components is available in our [Styles package](
 
 ## Packages
 
-The IBM.com Library comes with a variety of packages. While the main package used would be either [React](https://ibmdotcom-react.mybluemix.net)
+Carbon for IBM.com comes with a variety of packages. While the main package used would be either [React](https://ibmdotcom-react.mybluemix.net)
 or [Web Components](https://ibmdotcom-web-components.mybluemix.net), there are also separate packages that can be 
 utilized as their own standalone functionality. 
 

--- a/src/pages/get-started/designing.mdx
+++ b/src/pages/get-started/designing.mdx
@@ -1,11 +1,11 @@
 ---
 title: Designing
-description: Rapidly build beautiful and accessible experiences. The IBM.com Library and IBM.com Library Expressive kits contain all the resources you need to get started.
+description: Rapidly build beautiful and accessible experiences. Carbon for IBM.com and Carbon Expressive kits contain all the resources you need to get started.
 ---
 
 <PageDescription>
 
-Rapidly build beautiful and accessible experiences. The IBM.com Library kit and Carbon Design kits contain all the resources you need to get started.
+Rapidly build beautiful and accessible experiences. The Carbon for IBM.com kit and Carbon Design kits contain all the resources you need to get started.
 
 </PageDescription>
 
@@ -21,35 +21,35 @@ Rapidly build beautiful and accessible experiences. The IBM.com Library kit and 
 
 
 ## Introduction
-The IBM.com Library team is working to adopt the Carbon design system for IBM.com. Please check the [adoption paths](http://ibm-dotcom-library.mybluemix.net/get-started#how-to-decide-the-right-path-for-adoption) and discuss with your team before adopting the IBM.com Library.  
+The Carbon for IBM.com team is working to adopt the Carbon design system for IBM.com. Please check the [adoption paths](http://ibm-dotcom-library.mybluemix.net/get-started#how-to-decide-the-right-path-for-adoption) and discuss with your team before adopting Carbon for IBM.com.  
 
-The IBM.com Library kit includes expressive type styles for editorial experiences and IBM.com specific components including the IBM.com masthead and footer. Teams should utilize the Carbon design kits for core components such as buttons, form components, etc. If you have any questions please reach out on our [slack channel](https://cognitive-app.slack.com/archives/C2PLX8GQ6).
+The Carbon for IBM.com kit includes expressive type styles for editorial experiences and IBM.com specific components including the IBM.com masthead and footer. Teams should utilize the Carbon design kits for core components such as buttons, form components, etc. If you have any questions please reach out on our [slack channel](https://cognitive-app.slack.com/archives/C2PLX8GQ6).
 
 ## Get the kit
 
 **1. Install Sketch.**
-To design with the IBM.com Library kit you must have the most recent version of [Sketch](https://www.sketch.com) installed.
+To design with the Carbon for IBM.com kit you must have the most recent version of [Sketch](https://www.sketch.com) installed.
 
 **2. Set up Box Drive.**
 If you currently use Box Sync, you must uninstall it to use Box Drive. You can follow the steps on [Uninstalling Box Sync](https://community.box.com/t5/Using-Box-Sync/Uninstalling-Box-Sync-Manually/ta-p/51105?advanced=false&collapse_discussion=true&filter=location&location=category:English&q=unintall%20box%20sync&search_type=thread) Manually document to uninstall Box Sync and [Installing and Updating Box Drive](https://community.box.com/t5/Getting-Started-with-Box-Drive/Installing-and-Updating-Box-Drive/ta-p/37450) document to install the Box Drive.
 
-The IBM.com Library team releases frequent updates to the design kit. Follow the instructions above to stay up to date with the latest changes via Box Drive.
+The Carbon for IBM.com team releases frequent updates to the design kit. Follow the instructions above to stay up to date with the latest changes via Box Drive.
 
 **3. Set up Sketch library and templates.** 
 
-You can save the template and library by navigating to the `IBM.com Library design kit` folder.
+You can save the template and library by navigating to the `Carbon for IBM.com design kit` folder.
 
 To save the grid template, open the “IBM Design template” file in Sketch, from the menu choose `File → save as template → save`.
 
 Follow the same instructions for the "IBM.com Shell template".
 
-To add the libraries, from Sketch navigate to `Preferences → Libraries → Add Library` and select `Box →  IBM.com Library design kit → IBM.com Library (White theme)`.
+To add the libraries, from Sketch navigate to `Preferences → Libraries → Add Library` and select `Box →  Carbon for IBM.com design kit → Carbon for IBM.com (White theme)`.
 Follow the same instructions for the other theme libraries.
 
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="Request access to the IBM.com Library design kit "
+      subTitle="Request access to the Carbon for IBM.com design kit "
       href="https://github.com/carbon-design-system/ibm-dotcom-library-design-kit/issues/new?assignees=ljcarot%2C+wonilsuhibm%2C+oliviaflory&labels=adopter+support&template=request-access.md&title=Design+kit+access+request"
     >
 
@@ -59,7 +59,7 @@ Follow the same instructions for the other theme libraries.
   </Column>
 </Row>
 
-Be sure to add the libraries following the instructions above. The IBM.com Library team does not recommend downloading the Sketch files to your local drive because you will not receive the updates as they are published.
+Be sure to add the libraries following the instructions above. The Carbon for IBM.com team does not recommend downloading the Sketch files to your local drive because you will not receive the updates as they are published.
 
 For core components and product design, the [Carbon kit](https://www.carbondesignsystem.com/get-started/design/#get-the-kit) is available via Sketch Cloud and you do not have to request access to the box folder.
 
@@ -108,7 +108,7 @@ The full IBM color pallet lives in the [IBM Design Language library](sketch://ad
 
 
 ## Start designing
-To get started with the IBM.com Library kits, familiarize yourself with the contents of each library and template.
+To get started with the Carbon for IBM.com kits, familiarize yourself with the contents of each library and template.
 
 **Start with the grid.** At the top of your screen, navigate to `File → New file from Template` and select the “IBM Design template” or "IBM.com Shell template" file in Sketch. You’ll always be able to find the template there.
 

--- a/src/pages/get-started/index.mdx
+++ b/src/pages/get-started/index.mdx
@@ -10,7 +10,7 @@ IBM.com is a place for people to learn about, try, and buy IBM products and serv
 
 <PageDescription>
 
-Towards that end, IBM.com Library has been built with the goal of providing efficiency and consistency across IBM.com using IBM Design Language (IDL) principles and based on the Carbon Design System (Carbon). IBM.com Library is focused on supporting IBM.com applications and/or website owners who want to adopt IDL and Carbon and need specific features relevant to IBM.com.  
+Towards that end, Carbon for IBM.com has been built with the goal of providing efficiency and consistency across IBM.com using IBM Design Language (IDL) principles and based on the Carbon Design System (Carbon). Carbon for IBM.com is focused on supporting IBM.com applications and/or website owners who want to adopt IDL and Carbon and need specific features relevant to IBM.com.  
 
 </PageDescription>
 
@@ -22,15 +22,15 @@ Towards that end, IBM.com Library has been built with the goal of providing effi
 
 <AnchorLinks>
 
-<AnchorLink>What is included in IBM.com Library?</AnchorLink>
+<AnchorLink>What is included in Carbon for IBM.com?</AnchorLink>
 <AnchorLink>How to decide the right path for adoption</AnchorLink>
 <AnchorLink>Resources</AnchorLink>
 
 </AnchorLinks>
 
 
-## What is included in IBM.com Library?
-IBM.com Library includes the following:
+## What is included in Carbon for IBM.com?
+Carbon for IBM.com includes the following:
 
 * Components usage and code (e.g. Masthead and Footer)
 * Layout patterns usage and code (e.g. Lead Space and Table of Contents)
@@ -53,12 +53,12 @@ In the interim, while these templates are being built, page owners can use the D
 
 For more information, please visit [Marketing Platforms Drupal CMS website](https://w3.ibm.com/w3publisher/squad-pulse/marketing-platforms/drupal-cms#Links).
 
-### For websites or applications on v18 (Northstar), v19a, or earlier, make plans now to migrate your site to IBM.com Library
-This site explains how to get started with IBM.com Library. It provides links to the code repository, the storybook, usage guidelines, and additional resources for getting started. Keep in mind the following things as you get started:
+### For websites or applications on v18 (Northstar), v19a, or earlier, make plans now to migrate your site to Carbon for IBM.com
+This site explains how to get started with Carbon for IBM.com. It provides links to the code repository, the storybook, usage guidelines, and additional resources for getting started. Keep in mind the following things as you get started:
 
-* Carbon and the IBM.com Library is built using Node Package Manager (NPM), not the Content Delivery Network (CDN), so it requires a complete development rewrite, unlike prior design systems.
+* Carbon and Carbon for IBM.com is built using Node Package Manager (NPM), not the Content Delivery Network (CDN), so it requires a complete development rewrite, unlike prior design systems.
 * Carbon has a new 2x grid so everything needs to be designed understanding that grid.
-* It is open source, so any adopters are invited to contribute to the open source IBM.com Library.
+* It is open source, so any adopters are invited to contribute to the open source Carbon for IBM.com.
 
 To assist adopters through this transition, Digital Design can guide a team as they are getting started or if they want a code review. Reach out on our slack channel at [#ibm-digital-design](https://ibm-studios.slack.com/archives/C2PLX8GQ6).
 

--- a/src/pages/guidelines/expressive-theme.mdx
+++ b/src/pages/guidelines/expressive-theme.mdx
@@ -13,7 +13,7 @@ The Expressive Theme is a flavor of Carbon for IBM.com and web experiences, opti
 <AnchorLinks>
 
 <AnchorLink>Expressive Theme fundamentals</AnchorLink>
-<AnchorLink>Expressive Theme and the IBM.com Library</AnchorLink>
+<AnchorLink>Expressive Theme and Carbon for IBM.com</AnchorLink>
 <AnchorLink>Resources</AnchorLink>
 
 </AnchorLinks>
@@ -112,10 +112,10 @@ Container sizes were increased systematically to accommodate the larger type siz
 |`$container-05`|64px|72px|
 
 
-## Expressive Theme and the IBM.com Library
+## Expressive Theme and Carbon for IBM.com
 
-By default, the Expressive Theme is enabled in the IBM.com Library (starting in `v1.10.0`). This is to guarantee consistency across
-all IBM.com experiences. However, the expressive theme is also available as its own offering within the IBM.com Library
+By default, the Expressive Theme is enabled in Carbon for IBM.com (starting in `v1.10.0`). This is to guarantee consistency across
+all IBM.com experiences. However, the expressive theme is also available as its own offering within the Carbon for IBM.com
 styles package (available in `v1.9.0`). Read more about how to implement within any non-IBM.com applications at 
 <a href="https://carbon-expressive.mybluemix.net" target="_blank">https://carbon-expressive.mybluemix.net</a>.
 

--- a/src/pages/help/faqs.mdx
+++ b/src/pages/help/faqs.mdx
@@ -1,31 +1,31 @@
 ---
 title: FAQ
-description: What is IBM.com Library? Who works on IBM.com Library? How can I contribute? Here, we answer some of our frequently asked questions.
+description: What is Carbon for IBM.com? Who works on Carbon for IBM.com? How can I contribute? Here, we answer some of our frequently asked questions.
 ---
 
 <PageDescription>
 
-Below are some of the most frequently asked IBM.com Library questions. If there is a question not answered below, please don't hesitate to [contact us](https://cognitive-app.slack.com/archives/C2PLX8GQ6). 
+Below are some of the most frequently asked Carbon for IBM.com questions. If there is a question not answered below, please don't hesitate to [contact us](https://cognitive-app.slack.com/archives/C2PLX8GQ6). 
 
 </PageDescription>
 
 
-### What is IBM.com Library?
-IBM.com Library is a resource for the community of designers and developers involved in building IBM web pages and digital experiences. Its goal is to implement the IBM Design Language, which expresses IBM’s brand values across all customer touch points, both product and web.  IBM.com Library is the design system that replaces Northstar [v18](https://www.ibm.com/standards/web/v18/design/), [v19a](https://www.ibm.com/standards/web/faq.html) and even older versions like v17.
+### What is Carbon for IBM.com?
+Carbon for IBM.com is a resource for the community of designers and developers involved in building IBM web pages and digital experiences. Its goal is to implement the IBM Design Language, which expresses IBM’s brand values across all customer touch points, both product and web.  Carbon for IBM.com is the design system that replaces Northstar [v18](https://www.ibm.com/standards/web/v18/design/), [v19a](https://www.ibm.com/standards/web/faq.html) and even older versions like v17.
 
 ### What is Carbon?
-Carbon Design System aka [Carbon](https://www.carbondesignsystem.com) is how the IBM Design Language is implemented across IBM products. Choosing Carbon as the strategic solution for IBM.com Library ensures IBM has one consolidate design system across product and web. IBM.com Library works alongside Carbon to produce themes, components, patterns and guidelines to leverage IDL for IBM.com’s more expressive nature.
+Carbon Design System aka [Carbon](https://www.carbondesignsystem.com) is how the IBM Design Language is implemented across IBM products. Choosing Carbon as the strategic solution for Carbon for IBM.com ensures IBM has one consolidate design system across product and web. Carbon for IBM.com works alongside Carbon to produce themes, components, patterns and guidelines to leverage IDL for IBM.com’s more expressive nature.
 
 ### What happened to Duo?
-“Duo” was the codename for the redesign and revamp of the IBM Design Ethos and Language. This effort is still being carried out today throughout all of IBM Design. The new IBM Design Ethos and Language is directly influencing the evolution of IBM.com Library.
+“Duo” was the codename for the redesign and revamp of the IBM Design Ethos and Language. This effort is still being carried out today throughout all of IBM Design. The new IBM Design Ethos and Language is directly influencing the evolution of Carbon for IBM.com.
 
-### Is IBM.com Library ready to use? 
-It depends.  If your pages are on Drupal, the rollout of Carbon on Drupal is happening in 2020 with a new release of Drupal Publishing. If you are designing a new page/site or doing a re-design on a page, you can get started now with IBM.com Library and get familiar with the new dotcom library code. If you are with IBM Cloud and Watson marketing, v19a will continue for limited use until Drupal adopts Carbon in 2020.
+### Is Carbon for IBM.com ready to use? 
+It depends.  If your pages are on Drupal, the rollout of Carbon on Drupal is happening in 2020 with a new release of Drupal Publishing. If you are designing a new page/site or doing a re-design on a page, you can get started now with Carbon for IBM.com and get familiar with the new dotcom library code. If you are with IBM Cloud and Watson marketing, v19a will continue for limited use until Drupal adopts Carbon in 2020.
 
 ### When will v18 (Northstar) be sunset?
-Northstar is in steady state now.  This means no new enhancements. It will remain in place in 2020 with limited support but adopters are encouraged to make plans to migrate to IBM.com Library in 2020. In 2019, Ginni Rometty announced that Carbon is the overall strategic direction for IBM web and product experiences.  
+Northstar is in steady state now.  This means no new enhancements. It will remain in place in 2020 with limited support but adopters are encouraged to make plans to migrate to Carbon for IBM.com in 2020. In 2019, Ginni Rometty announced that Carbon is the overall strategic direction for IBM web and product experiences.  
 
-### Is there anything not available in IBM.com Library?
+### Is there anything not available in Carbon for IBM.com?
 In order to stay current with what’s coming, read the [Release Schedule]( https://github.com/carbon-design-system/ibm-dotcom-library/issues) pinned on our Github.  
 
 ### Where can I get current information?

--- a/src/pages/help/index.mdx
+++ b/src/pages/help/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Help
-description: The help page for IBM.com Library
+description: The help page for Carbon for IBM.com
 ---
 
 <PageDescription>
 
-The IBM.com Library core team provides support for users of the design system. Find the use case below that most closely matches your own for the quickest response.
+The Carbon for IBM.com core team provides support for users of the design system. Find the use case below that most closely matches your own for the quickest response.
 
 </PageDescription>
 
@@ -19,14 +19,14 @@ The IBM.com Library core team provides support for users of the design system. F
 
 ## Questions
 
-### IBM.com Library website
-Please take some time to explore the content on this website before engaging the IBM.com Library core team. The site is very comprehensive and most of the guidelines and components are well documented.
+### Carbon for IBM.com website
+Please take some time to explore the content on this website before engaging the Carbon for IBM.com core team. The site is very comprehensive and most of the guidelines and components are well documented.
 
 ### Frequently asked questions
 Answers to the most common questions about the design system can be found in the [FAQ](/help/faqs).
 
 ### Slack channels
-_Internal IBM users only. The IBM.com Library core team maintains the following channels and will provide support as time permits._
+_Internal IBM users only. The Carbon for IBM.com core team maintains the following channels and will provide support as time permits._
 
 **Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the DataTable component, you could search “DataTable” in Slack and then filter by the #ibm-digital-design channel. 
 
@@ -35,10 +35,10 @@ _Tip: You can start a new search directly from the message box using the /s slas
 ## Suggestions or contributions
 
 ### GitHub pull requests
-If you have a specific fix or contribution, you can generate a pull request in the appropriate IBM.com Library repo.
+If you have a specific fix or contribution, you can generate a pull request in the appropriate Carbon for IBM.com repo.
 
 ### GitHub issues
-Bug reports, feature requests, and general feedback can be delivered to the IBM.com Library team via the creation of a [GitHub](https://github.com/carbon-design-system/ibm-dotcom-library/issues/new/choose) issue.
+Bug reports, feature requests, and general feedback can be delivered to the Carbon for IBM.com team via the creation of a [GitHub](https://github.com/carbon-design-system/ibm-dotcom-library/issues/new/choose) issue.
 
 **Design issues**
 - [Accessibility](https://github.com/carbon-design-system/ibm-dotcom-library/issues/new/choose)

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -33,7 +33,7 @@ building websites and user interfaces. See a
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
    <ResourceCard
-       subTitle="IBM.com Library Components Repo"
+       subTitle="Carbon for IBM.com Components Repo"
        target="_blank"
        href="https://github.com/carbon-design-system/ibm-dotcom-library"
        >
@@ -44,7 +44,7 @@ building websites and user interfaces. See a
   </Column>
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="IBM.com Library Pattern React Storybook"
+    subTitle="Carbon for IBM.com React Storybook"
     target="_blank"
     href="https://ibmdotcom-react.mybluemix.net/?path=/story/overview-get-started--default"
     >

--- a/src/pages/patterns/cards.mdx
+++ b/src/pages/patterns/cards.mdx
@@ -195,7 +195,7 @@ There are two options to consider when positioning an icon on a card:
 
 ![Card link](../../images/pattern/cards/cards-icons-1.jpg)
 
-This is the default and most common option, recommended by IBM.com Library. Having the icon in this position creates clear visual alignment with all text fields on the card.
+This is the default and most common option, recommended by Carbon for IBM.com. Having the icon in this position creates clear visual alignment with all text fields on the card.
 
 2. bottom-right, 16px from the edge 
 

--- a/src/pages/patterns/index.mdx
+++ b/src/pages/patterns/index.mdx
@@ -5,7 +5,7 @@ description: Patterns are guidelines based on best practice design solutions.
 
 <PageDescription>
 
-IBM.com Library patterns are guidelines that are tailored to meet the needs of IBM.com users and implemented by makers to establish greater design consistency across IBM.com. They are based on best practice design solutions for user-centered tasks, digital content types, and web page intents. They show reusable combinations of components, layouts, and flows that address common user objectives.
+Carbon for IBM.com patterns are guidelines that are tailored to meet the needs of IBM.com users and implemented by makers to establish greater design consistency across IBM.com. They are based on best practice design solutions for user-centered tasks, digital content types, and web page intents. They show reusable combinations of components, layouts, and flows that address common user objectives.
 
 </PageDescription>
 

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Resources
-description: IBM.com Library Resources page
+description: Carbon for IBM.com Resources page
 ---
 
 <PageDescription>
 
-Everything you need to learn about, work with, and contribute to IBM.com Library.
+Everything you need to learn about, work with, and contribute to Carbon for IBM.com.
 
 </PageDescription>
 
@@ -23,7 +23,7 @@ Everything you need to learn about, work with, and contribute to IBM.com Library
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library"
+  subTitle="Carbon for IBM.com"
   href="https://github.com/carbon-design-system/ibm-dotcom-library"
 >
 
@@ -32,7 +32,7 @@ Everything you need to learn about, work with, and contribute to IBM.com Library
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library NextJS Template"
+  subTitle="Carbon for IBM.com NextJS Template"
   href="https://github.com/carbon-design-system/ibm-dotcom-library-nextjs-template"
 >
 
@@ -46,7 +46,7 @@ Everything you need to learn about, work with, and contribute to IBM.com Library
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Storybook React"
+  subTitle="Carbon for IBM.com Storybook React"
   href="https://ibmdotcom-react.mybluemix.net"
 >
 
@@ -57,7 +57,7 @@ Everything you need to learn about, work with, and contribute to IBM.com Library
 
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="IBM.com Library Storybook Web Components"
+  subTitle="Carbon for IBM.com Storybook Web Components"
   href="https://ibmdotcom-web-components.mybluemix.net"
 >
 
@@ -115,11 +115,11 @@ Everything you need to learn about, work with, and contribute to IBM.com Library
 
 ## Design resources
 
-### IBM.com Library
+### Carbon for IBM.com
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-  subTitle="Request access to the IBM.com Library design kit"
+  subTitle="Request access to the Carbon for IBM.com design kit"
   href="https://github.com/carbon-design-system/ibm-dotcom-library-design-kit/issues/new?assignees=ljcarot%2C+wonilsuhibm%2C+oliviaflory&labels=adopter+support&template=request-access.md&title=Design+kit+access+request"
 >
 
@@ -255,10 +255,10 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
 <br/>
 
 #### IBM Plex 
-IBM.com Library uses the open-source typeface [IBM Plex](https://github.com/ibm/plex) – carefully designed to meet IBM’s needs as a global technology company and reflect IBM’s spirit, beliefs, and design principles.
+Carbon for IBM.com uses the open-source typeface [IBM Plex](https://github.com/ibm/plex) – carefully designed to meet IBM’s needs as a global technology company and reflect IBM’s spirit, beliefs, and design principles.
 
 #### IBM Design Language
-IBM.com Library delivers the [IBM Design Language](https://www.ibm.com/design/language/) as tools for designers and developers, guidance, tutorials, and support. 
+Carbon for IBM.com delivers the [IBM Design Language](https://www.ibm.com/design/language/) as tools for designers and developers, guidance, tutorials, and support. 
 
 #### Carbon Design System
 [Carbon](https://www.carbondesignsystem.com) is the open-source design system for IBM products experiences. 


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This PR covers the global rename from `IBM.com Library` to `Carbon for IBM.com`.

### Changelog

**Changed**

- Global rename to `Carbon for IBM.com`
