### PR TITLE
tabs extended remove notification

### DIFF
--- a/src/pages/components/tabs-extended.mdx
+++ b/src/pages/components/tabs-extended.mdx
@@ -13,12 +13,6 @@ import ResourceLinks from "components/ResourceLinks";
 
 <ComponentDescription name="Tabs extended" type="ui" />
 
-<InlineNotification>
-
-**Note:** Additional usage guidelines are coming soon.
-
-</InlineNotification>
-
 <AnchorLinks>
 <AnchorLink>Overview</AnchorLink>
 <AnchorLink>Tabs extended</AnchorLink>


### PR DESCRIPTION
This PR removes the notification that says additional guidance is coming soon. We've just added guidance and the notification is not necessary. 